### PR TITLE
✨ Add model version control with dvc

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,4 @@
+[core]
+    remote = storage
+['remote "storage"']
+    url = gdrive://1O9D3t9n1sx9gsCie-bloF9viYy4GoR0r

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,0 +1,1 @@
+/best-checkpoint-v1.ckpt

--- a/models/best-checkpoint-v1.ckpt.dvc
+++ b/models/best-checkpoint-v1.ckpt.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: cb35da63eb9e975dbc79ef575dd9f225
+  size: 52687985
+  hash: md5
+  path: best-checkpoint-v1.ckpt

--- a/models/best-checkpoint-v1.ckpt.dvc
+++ b/models/best-checkpoint-v1.ckpt.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: cb35da63eb9e975dbc79ef575dd9f225
-  size: 52687985
+- md5: f3ae4f073d8bcf45db4d2af356ff4f7c
+  size: 52688049
   hash: md5
   path: best-checkpoint-v1.ckpt

--- a/train_model.py
+++ b/train_model.py
@@ -110,9 +110,9 @@ def main(cfg: DictConfig) -> None:
         log_every_n_steps=cfg.training.log_every_n_steps,  # This is way too high,
         # specially on such a pretrained model, but this is a demo
         deterministic=cfg.training.deterministic,  # For reproducibility
-        limit_train_batches=cfg.training.limit_train_batches,
+        # limit_train_batches=cfg.training.limit_train_batches,
         # Reduce data size for testing
-        limit_val_batches=cfg.training.limit_val_batches,
+        # limit_val_batches=cfg.training.limit_val_batches,
     )
     trainer.fit(bert_model, cola_data)
     wandb.finish()


### PR DESCRIPTION
- Add .dvc config files
- Remove model from git
- Push models to remote storage, used gdrive for testing
- Removed training limit to re train and save fully trained models
- Added local directories gitignores (using dvc)
- Created tags 0.0 and 0.1 of model retraining with increased epochs (1 and 3, respectively) this configs are saved in gdrive with dvc